### PR TITLE
Docker watch

### DIFF
--- a/python/basic/watch.py
+++ b/python/basic/watch.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+'''
+
+Implements a watch mode for docker-compose
+
+
+'''
+
+import subprocess
+import os
+import signal
+import argparse
+from inotify_simple import INotify, flags
+
+parser = argparse.ArgumentParser(description='Watch mode for docker-compose.')
+parser.add_argument('--kill', dest='should_kill', action='store_true')
+args = parser.parse_args()
+
+inotify = INotify()
+watch_flags = flags.CREATE | flags.DELETE | flags.MODIFY | flags.DELETE_SELF
+wd = inotify.add_watch('.', watch_flags)
+
+def watch_loop():
+
+	print("Rebuilding and bringing docker-compose up...\n");		
+	process = subprocess.Popen(['docker-compose', 'up', '--build'])
+
+	#wait for an event based on our watch flags
+	#the loop will end when something happens
+	for event in inotify.read():
+	    for flag in flags.from_mask(event.mask):
+	        action = str(flag).split('.')[1]
+	        print(f'\n{action}: {event.name}\n')
+
+	if (args.should_kill):
+		#this will ungracefully terminate - which may well be fine, and is faster!
+		print("Terminating docker-compose process...\n");		
+		process.kill()
+	else:
+		#shut down gracefully
+		print("Sending CTRL^C to docker-compose process...\n");		
+		process.send_signal(signal.SIGINT)
+		process.wait()
+	
+	#start again
+	watch_loop()
+
+#start things off
+watch_loop()

--- a/python/basic/watch.py
+++ b/python/basic/watch.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
 '''
-
 Implements a watch mode for docker-compose
-
 
 '''
 
@@ -13,13 +11,22 @@ import signal
 import argparse
 from inotify_simple import INotify, flags
 
+start_dir = "."
+
 parser = argparse.ArgumentParser(description='Watch mode for docker-compose.')
 parser.add_argument('--kill', dest='should_kill', action='store_true')
 args = parser.parse_args()
 
 inotify = INotify()
 watch_flags = flags.CREATE | flags.DELETE | flags.MODIFY | flags.DELETE_SELF
-wd = inotify.add_watch('.', watch_flags)
+
+inotify.add_watch(start_dir, watch_flags)
+
+#recursively setup the watches
+for root, dirs, files in os.walk(start_dir):
+	for dir in dirs:
+		print("Watching: ", root + os.sep + dir)
+		inotify.add_watch(root + os.sep + dir, watch_flags)
 
 def watch_loop():
 


### PR DESCRIPTION
Because of the way this template has been designed - there's no easy way to get a watch mode going which slows down development. We could potentially move towards mounting the source code as a volume, and then having a watch script running inside the container, but this would also need to recopy files, which means pulling the logic out of the Dockerfile into a script.

This is a half-way house. It will rebuild and bring up your docker-compose when it detects changes to any source files. There is an optional "--kill" parameter which will terminate your containers rather than cleanly exit. If you are not using mounted volume, I'm fairly sure this is safe enough to use and it's faster.

The downside is that this will only work on Linux, as it's using iNotify - which I thought was also present on OSX. It's not. 

https://github.com/emcrisostomo/fswatch

I think we might want to move to something like this instead.

