### PR TITLE
dotnet template query complexity for deeper nesting and larger types

### DIFF
--- a/dotnet_core/cs/basic/README.md
+++ b/dotnet_core/cs/basic/README.md
@@ -158,7 +158,7 @@ Relay must be enabled in the CustomServiceCollectionExtensions.cs file--it is cu
 ## Query Depth and Complexity
 dotnet-graphql allows for validation to include GraphQL query depth and complexity. Critically, this can prevent denial of service (DOS) where a query's computational or spacial complexity can exceeed a server's resources. 
 
-This can be adjusted as needed in the appsettings.json file.
+This can be adjusted as needed in the appsettings.json file. Defaults are depth=50 and complexity=1000 (calculated by each field requested being equal to 1 point of complexity).
 
 ## Authorization -- Claim-based access
 Authorization is disabled in this template. 

--- a/dotnet_core/cs/basic/appsettings.json
+++ b/dotnet_core/cs/basic/appsettings.json
@@ -23,9 +23,9 @@
     // Set some limits for security (See https://www.howtographql.com/advanced/4-security).
     "ComplexityConfiguration": {
       // The total maximum nesting across all queries in a request.
-      "MaxDepth": 15,
+      "MaxDepth": 50,
       // The total maximum complexity allowed in a request. Each field returned is given a default complexity of 1.
-      "MaxComplexity": 250
+      "MaxComplexity": 1000
     },
     "EnableMetrics": true
   },


### PR DESCRIPTION
Increase complexity settings to account for more nesting of larger types; add README note on defaults.